### PR TITLE
Cleared the zip from faulty AgentNames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ eggs/
 .eggs/
 lib/
 lib64/
+.DS_Store
 parts/
 sdist/
 var/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 Random User Agents
 ==================
 
+Use this command to install this forked version:
+
+```bash
+pip install -e git+https://github.com/iVictory2004/random_user_agent.git#egg=random_user_agent
+```
+
 Random User Agents is a python library that provides list of user agents,
 from a collection of more than 326,000+ user agents, based on filters.
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Installation
 ------------
 
 You can install random_useragent by running the following command:
-
+```bash
   pip install -e git+https://github.com/iVictory2004/random_user_agent.git#egg=random_user_agent
-
+```
 Or you can download direct from [Github](https://github.com/Luqman-Ud-Din/random_user_agent) and install it manually.
 
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Installation
 
 You can install random_useragent by running the following command:
 
-    pip install random_user_agent
+  pip install -e git+https://github.com/iVictory2004/random_user_agent.git#egg=random_user_agent
 
 Or you can download direct from [Github](https://github.com/Luqman-Ud-Din/random_user_agent) and install it manually.
 

--- a/random_user_agent/user_agent.py
+++ b/random_user_agent/user_agent.py
@@ -14,9 +14,11 @@ class UserAgent:
         'popularity': [],
     }
 
-    def __init__(self, limit=None, *args, **kwargs):
+    def __init__(self, all =False, limit=None, *args, **kwargs):
         self.user_agents = []
-
+        if all:
+            self.user_agents = self.load_user_agents()
+            return
         for attribute, values in self.ATTRIBUTES_MAP.items():
             setattr(self, attribute, kwargs.get(attribute, [v.lower() for v in values]))
 
@@ -51,7 +53,6 @@ class UserAgent:
         with zipfile.ZipFile(file_path) as zipped_user_agents:
             with zipped_user_agents.open('user_agents.jl') as user_agents:
                 for user_agent in user_agents:
-
                     if hasattr(user_agent, 'decode'):
                         user_agent = user_agent.decode()
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(os.path.dirname(__file__), "README.md"), "r") as fh:
 
 setuptools.setup(
     name="random_user_agent",
-    version="1.0.1",
+    version="1.0.2",
     author="Luqman-Ud-Din Muhammad",
     author_email="luqmanuddinm@gmail.com",
     description="A package to get random user agents based filters provided by user",


### PR DESCRIPTION
I'm pretty sure this Closes #9 of @matt-slalom
Some of them contained ["] inside the UserAgent value so I just did a search on all of them and removed the enclosing quotes

Oh, also added an init parrametter in case you simply wanna get all the possible 300k configurations for some reason, I mean this god forsaken package loads all of them in your memoery at init eitherway, you might as well use them